### PR TITLE
Checkout with fetch-depth: 0 and set --tags on git describe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on: 
-  pull_request:
-    branches: [master]
-# TRIGGER?
+  release:
+    types: [created]
+
 env:
   GITHUB_TOKEN: ${{ github.token }}
 
@@ -29,8 +29,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Fetch Tags # Run this step in order to get all annotated and unannotated tags
-        run: git fetch --force --tags
       - name: Install
         run: python3 main.py
       - name: Build
@@ -40,3 +38,11 @@ jobs:
         uses: bruceadams/get-release@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
 on: 
-  release:
-    types: [created]
+  pull_request:
+    branches: [master]
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -38,11 +38,3 @@ jobs:
         uses: bruceadams/get-release@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref }}
-          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch_depth: 1
+          fetch-depth: 0
       - name: Install
         run: python3 main.py
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
-on: 
-  pull_request:
-    branches: [master]
+on:
   release:
     types: [created]
 
@@ -28,10 +26,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
-#         uses: actions/checkout@v2
-#         with:
-#           fetch_depth: 1
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install
         run: python3 main.py
       - name: Build
@@ -41,11 +38,11 @@ jobs:
         uses: bruceadams/get-release@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#       - name: Upload binaries to release
-#         uses: svenstaro/upload-release-action@v2
-#         with:
-#           repo_token: ${{ secrets.GITHUB_TOKEN }}
-#           file: dist/${{ matrix.artifact_name }}
-#           asset_name: ${{ matrix.asset_name }}
-#           tag: ${{ github.ref }}
-#           overwrite: true
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on: 
   pull_request:
     branches: [master]
-
+# TRIGGER?
 env:
   GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 on: 
+  pull_request:
+    branches: [master]
   release:
     types: [created]
 
@@ -26,9 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v1
+#         uses: actions/checkout@v2
+#         with:
+#           fetch_depth: 1
       - name: Install
         run: python3 main.py
       - name: Build
@@ -38,11 +41,11 @@ jobs:
         uses: bruceadams/get-release@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/${{ matrix.artifact_name }}
-          asset_name: ${{ matrix.asset_name }}
-          tag: ${{ github.ref }}
-          overwrite: true
+#       - name: Upload binaries to release
+#         uses: svenstaro/upload-release-action@v2
+#         with:
+#           repo_token: ${{ secrets.GITHUB_TOKEN }}
+#           file: dist/${{ matrix.artifact_name }}
+#           asset_name: ${{ matrix.asset_name }}
+#           tag: ${{ github.ref }}
+#           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Fetch Tags # Run this step in order to get all annotated and unannotated tags
+        run: git fetch --force --tags
       - name: Install
         run: python3 main.py
       - name: Build

--- a/aeroconfig.py
+++ b/aeroconfig.py
@@ -14,7 +14,7 @@ def build():
     # get date
     date = datetime.now(timezone.utc)
     # get last commit
-    commit = subprocess.check_output(["git", "describe", "--tags"])
+    commit = subprocess.check_output(["git", "describe"]) # , "--tags"])
     # now we output all this information to a json friendly file in our dist folder
     file = Path('./dist/build.json')
     jsonData = json.dumps(obj={

--- a/aeroconfig.py
+++ b/aeroconfig.py
@@ -14,7 +14,7 @@ def build():
     # get date
     date = datetime.now(timezone.utc)
     # get last commit
-    commit = subprocess.check_output(["git", "describe"])
+    commit = subprocess.check_output(["git", "describe", "--tags"])
     # now we output all this information to a json friendly file in our dist folder
     file = Path('./dist/build.json')
     jsonData = json.dumps(obj={

--- a/aeroconfig.py
+++ b/aeroconfig.py
@@ -14,7 +14,7 @@ def build():
     # get date
     date = datetime.now(timezone.utc)
     # get last commit
-    commit = subprocess.check_output(["git", "describe"]) # , "--tags"])
+    commit = subprocess.check_output(["git", "describe", "--tags"])
     # now we output all this information to a json friendly file in our dist folder
     file = Path('./dist/build.json')
     jsonData = json.dumps(obj={


### PR DESCRIPTION
@dragonDScript

Although the changes in this PR won't fix all of the tests issues, I believe it'll allow the builds to move farther along than where they were breaking earlier. Here's the pull request where I experimented on my fork: https://github.com/emmasax4/aero/pull/1, and [here's the farthest that I managed to get the builds to get to](https://github.com/emmasax4/aero/runs/1647904912?check_suite_focus=true) (with minimal time and energy spent 😉 ).

I'm not super familiar with Python or Windows or anything like that, but I think the builds on my experimentation PR (what is linked above) break in a later place than in [the original build you linked in the other issue](https://github.com/X-Store-App/aero/runs/1636845891?check_suite_focus=true) (https://github.com/actions/checkout/issues/409).

I think the next thing to do would be to upload that `dist/build.json` file to the project, and maybe the whole job would build correctly.

Just so it's extra clear, the issue on your original build is not actually the checkout step at all, but rather adding the `--tags` flag to the `git describe` in the `aeroconfig.py`. More information [here](https://github.com/actions/checkout/issues/290). Please let me know if you have any questions or concerns.